### PR TITLE
Fix/org hours validation

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -294,6 +294,19 @@ class OrganizationCreateUpdateSerializer(serializers.ModelSerializer):
         district = validated_data.pop('district')
         town = validated_data.get('town')
 
+        is_full_time = validated_data.get('is_full_time')
+        business_hours = validated_data.get('business_hours')
+
+        if is_full_time and business_hours:
+            raise serializers.ValidationError(
+                'Организация либо круглосуточная, либо по графику'
+            )
+
+        if not is_full_time and not business_hours:
+            raise serializers.ValidationError(
+                'Нет информации о графике работы организации'
+            )
+
         try:
             validated_data['district'] = (
                 District

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 
 from django.contrib.auth.hashers import make_password
 from django.core.exceptions import ObjectDoesNotExist
@@ -16,6 +15,7 @@ from organizations.models import (Appointment, District,
                                   Specialty, Town)
 from user.models import User
 from .fields import DistrictField, SlugRelatedFieldWith404
+from .utils import FIO_REGEX, PHONE_NUMBER_REGEX, haversine
 
 
 class SpecialtySerializer(serializers.ModelSerializer):
@@ -232,7 +232,7 @@ class OrganizationCreateUpdateSerializer(serializers.ModelSerializer):
         read_only=True)
 
     town = SlugRelatedFieldWith404(
-        queryset=Town.objects.only('id').all(),
+        queryset=Town.objects.all(),
         slug_field='name',
         help_text='Город расположения организации')
 
@@ -291,21 +291,38 @@ class OrganizationCreateUpdateSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
 
         validated_data = super().validate(attrs)
+
         district = validated_data.pop('district')
         town = validated_data.get('town')
 
         is_full_time = validated_data.get('is_full_time')
         business_hours = validated_data.get('business_hours')
 
+        errors = dict()
+
+        if haversine(
+                town.longitude,
+                town.latitude,
+                validated_data.get('longitude'),
+                validated_data.get('latitude')
+        ) > Town.MAX_DIST:
+            errors['latitude & longitude'] = (f'Организация слишком далеко '
+                                              f'расположена от центра города'
+                                              f' (больше допустимых'
+                                              f' {Town.MAX_DIST} километров).')
+
         if is_full_time and business_hours:
-            raise serializers.ValidationError(
-                'Организация либо круглосуточная, либо по графику'
-            )
+            errors['is_full_time & business_hours'] = ('Организация либо '
+                                                       'круглосуточная, '
+                                                       'либо по графику')
 
         if not is_full_time and not business_hours:
-            raise serializers.ValidationError(
-                'Нет информации о графике работы организации'
-            )
+            errors['is_full_time & business_hours'] = ('Нет информации о '
+                                                       'графике работы '
+                                                       'организации')
+
+        if errors:
+            raise serializers.ValidationError(errors)
 
         try:
             validated_data['district'] = (
@@ -402,22 +419,17 @@ class AppointmentListSerializer(serializers.ModelSerializer):
 class AppointmentCreateSerializer(serializers.Serializer):
     """Сериализатор записи к специальности врача организации."""
 
-    fio_pattern = re.compile(r'([А-ЯЁ][а-яё]+)\s([А-ЯЁ][а-яё]+)\s([А-ЯЁ]['
-                             r'а-яё]+)$')
-    phone_pattern = re.compile(r'^(\+7|7|8)?[\s\-]?\(?[489][0-9]{2}\)?[\s\-]?'
-                               r'[0-9]{3}[\s\-]?[0-9]{2}[\s\-]?[0-9]{2}$')
-
     fio = serializers.CharField(
         min_length=8,
         max_length=255,
         required=True,
-        validators=[RegexValidator(regex=fio_pattern)],
+        validators=[RegexValidator(regex=FIO_REGEX)],
         help_text='ФИО пациента'
     )
 
     phone = serializers.CharField(
         required=True,
-        validators=[RegexValidator(regex=phone_pattern)],
+        validators=[RegexValidator(regex=PHONE_NUMBER_REGEX)],
         help_text='Номер телефона пациента')
 
     email = serializers.EmailField(

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,5 +1,12 @@
+import re
+from math import radians, cos, sin, asin, sqrt
+
 from django.db.models import F
 from django.db.models.functions import ATan2, Cos, Power, Radians, Sin, Sqrt
+
+PHONE_NUMBER_REGEX = re.compile(r'^(\+7|7|8)?[\s\-]?\(?[489][0-9]{2}\)?[\s\-]?'
+                                r'[0-9]{3}[\s\-]?[0-9]{2}[\s\-]?[0-9]{2}$')
+FIO_REGEX = re.compile(r'([А-ЯЁ][а-яё]+)\s([А-ЯЁ][а-яё]+)\s([А-ЯЁ][а-яё]+)$')
 
 
 def count_distance(cur_longitude, cur_latitude):
@@ -13,4 +20,15 @@ def count_distance(cur_longitude, cur_latitude):
          )
 
     c = 2 * ATan2(Sqrt(a), Sqrt(1 - a))
+    return 6371 * c
+
+
+def haversine(lon1, lat1, lon2, lat2) -> float:
+    """Возвращает расстояние в километрах между двумя точками планеты."""
+
+    lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+    dlon = lon2 - lon1
+    dlat = lat2 - lat1
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    c = 2 * asin(sqrt(a))
     return 6371 * c

--- a/backend/organizations/migrations/0008_added_max_length_to_org_about_field.py
+++ b/backend/organizations/migrations/0008_added_max_length_to_org_about_field.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('organizations', '0007_added_org_owner'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organization',
+            name='about',
+            field=models.TextField(
+                blank=True,
+                help_text='Дополнительная информация об организации',
+                max_length=500, null=True,
+                verbose_name='Дополнительная информация'),
+        ),
+    ]

--- a/backend/organizations/migrations/0009_changed_max_lenth_field_org_phone.py
+++ b/backend/organizations/migrations/0009_changed_max_lenth_field_org_phone.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('organizations', '0008_added_max_length_to_org_about_field'),
+    ]
+
+    operations = [
+
+        migrations.AlterField(
+            model_name='organization',
+            name='phone',
+            field=models.CharField(
+                blank=True, help_text='Телефон организации',
+                                   max_length=20, null=True,
+                                   verbose_name='Номер телефона'),
+        ),
+    ]

--- a/backend/organizations/models/organization.py
+++ b/backend/organizations/models/organization.py
@@ -77,7 +77,8 @@ class Organization(models.Model):
         'Дополнительная информация',
         null=True,
         blank=True,
-        help_text='Дополнительная информация об организации')
+        help_text='Дополнительная информация об организации',
+        max_length=500)
 
     town = models.ForeignKey(
         Town,

--- a/backend/organizations/models/organization.py
+++ b/backend/organizations/models/organization.py
@@ -58,7 +58,7 @@ class Organization(models.Model):
 
     phone = models.CharField(
         'Номер телефона',
-        max_length=18,
+        max_length=20,
         null=True,
         blank=True,
         help_text='Телефон организации')

--- a/backend/organizations/models/town.py
+++ b/backend/organizations/models/town.py
@@ -4,6 +4,8 @@ from django.db import models
 class Town(models.Model):
     """Описание модели города."""
 
+    MAX_DIST = 25
+
     name = models.CharField(
         'Наименование города',
         help_text='Наименование города',


### PR DESCRIPTION
Добавлена валидация полей долготы и широты организации, обработки ситуации, когда приходит is_full_time + массив с рабочими часами

Выходит примерно следующее:
```text
1) short_name - ограничение длины строки (250 символов), строка
2) factual_addres - в идеале с использованием геосаджестера от яндекса, кастомная валидация лишняя, строка, ограничение длины (250) 
3) широта + долгота - числа,  точка  не дальше 25 км от центра города, 
4) сайт - ограничение длины строки (100)
5) город - должен быть из списка поддерживаемых в сервисе, строка
6) район - должен быть из списка поддерживаемых в сервисе районов выбранного города, строка
7) о чем  - строка, ограничение длины (500)
8) рабочие часы - массив. Либо часы, либо is_full_time=true - что-то одно
9) специальности - массив, необязательный
10) телефон - регулярка, макс символов - 20
```